### PR TITLE
poprawki na dzien dziecka

### DIFF
--- a/aplikacja-przychodnia/aplikacja-przychodnia/Classes/FirmLocalDataBase.cs
+++ b/aplikacja-przychodnia/aplikacja-przychodnia/Classes/FirmLocalDataBase.cs
@@ -108,5 +108,43 @@ namespace aplikacja_przychodnia.Classes
 
             return null;
         }
+
+
+        /// <summary>
+        /// Metoda sprawdzająca czy nie ma już zarejestrowanej firmy o podanym numerze nip
+        /// </summary>
+        /// <param name="nip">nip który chcemy sprawdzić</param>
+        /// <returns>informację w postaci true lub false</returns>
+        public bool IsNipAvailable(string nip)
+        {
+            foreach( Firm f in listOfFirms)
+            {
+                if (f.NIP == nip)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Metoda sprawdzająca czy nie ma już zarejestrowanej firmy o podanej nazwie
+        /// </summary>
+        /// <param name="nip">nazwa którą chcemy sprawdzić</param>
+        /// <returns>informację w postaci true lub false</returns>
+        public bool IsNameAvailable(string name)
+        {
+            if (name != "")
+            {
+                foreach (Firm f in listOfFirms)
+                {
+                    if (f.FirmName == name)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
     }
 }

--- a/aplikacja-przychodnia/aplikacja-przychodnia/Pages/AdminPage.xaml.cs
+++ b/aplikacja-przychodnia/aplikacja-przychodnia/Pages/AdminPage.xaml.cs
@@ -117,11 +117,19 @@ namespace aplikacja_przychodnia.Pages
         }
 
         private void ButtonFirm_Delete_Click(object sender, RoutedEventArgs e)
-        {
-            Firm firm = FirmView.SelectedItem as Firm;
-            FirmLocalDataBase.Remove(firm);
-            FirmLocalDataBase.Save();
-            RefreshFirmsView();
+        { 
+            
+            if (MessageBox.Show("Usunąć dane firmy?", "Potwierdzenie usuwania firmy", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.No)
+            {
+                //do no stuff
+            }
+            else
+            {
+                Firm firm = FirmView.SelectedItem as Firm;
+                FirmLocalDataBase.Remove(firm);
+                FirmLocalDataBase.Save();
+                RefreshFirmsView();
+            }
         }
     }
 }

--- a/aplikacja-przychodnia/aplikacja-przychodnia/Pages/PatientChoosePage.xaml.cs
+++ b/aplikacja-przychodnia/aplikacja-przychodnia/Pages/PatientChoosePage.xaml.cs
@@ -46,9 +46,18 @@ namespace aplikacja_przychodnia.Pages
                     connectionString = FirmLocalDataBase.FindFirmConnectionByNIP(nip);
                 }
                 else
-                { 
-                    connectionString = FirmLocalDataBase.FindFirmConnectionByName(nip);
+                {
+                    if (nip != "")
+                    {
+                        connectionString = FirmLocalDataBase.FindFirmConnectionByName(nip);
+                    }
+                    else
+                    {
+                        connectionString = null;
+                    }
                 }
+
+
                 if (connectionString != null)
                 {
                     long pesel = 0;

--- a/aplikacja-przychodnia/aplikacja-przychodnia/Pages/SickLeaveSchemePage.xaml.cs
+++ b/aplikacja-przychodnia/aplikacja-przychodnia/Pages/SickLeaveSchemePage.xaml.cs
@@ -139,7 +139,7 @@ namespace aplikacja_przychodnia.Pages
         private bool CheckDataCorrectness()
         {
             if (Input_PatientFirstNameBox.Text == "" || Input_PatientLastNameBox.Text == "" ||
-            Input_SickLeaveTypeList.Text == "" || Input_PatientGenderList.Text == "" || Input_PESELBox.Text == "" || Input_DateFromPicker.Text == "" || Input_DateToPicker.Text == "")
+            Input_SickLeaveTypeList.Text == "" || Input_PatientGenderList.Text == "" || Input_PESELBox.Text == "" || Input_DateFromPicker.Text == "" || Input_DateToPicker.Text == "" || Input_SymptomsBox.Text == "")
             {
                 Output_Error.Text = "Pola nie mogą być puste";
                 return false;
@@ -149,12 +149,15 @@ namespace aplikacja_przychodnia.Pages
                 Output_Error.Text = "";
             }
 
-            if (DateTime.Compare(Convert.ToDateTime(Input_DateFromPicker.Text), Convert.ToDateTime(Input_DateToPicker.Text)) >= 0
-                || DateTime.Compare(DateTime.Now.Date, Convert.ToDateTime(Input_DateFromPicker.Text)) > 0)
+            if (DateTime.Compare(Convert.ToDateTime(Input_DateFromPicker.Text), Convert.ToDateTime(Input_DateToPicker.Text)) > 0
+                || DateTime.Compare(DateTime.Now.Date, Convert.ToDateTime(Input_DateFromPicker.Text)) < -3
+                || DateTime.Compare(DateTime.Now.Date, Convert.ToDateTime(Input_DateFromPicker.Text)) > 4 )
             {
                 Output_Error.Text = "Podano nieprawidłowy\nzakres czasu";
                 return false;
             }
+
+
             return true;
         }
 

--- a/aplikacja-przychodnia/aplikacja-przychodnia/Windows/NewFirmWindow.xaml.cs
+++ b/aplikacja-przychodnia/aplikacja-przychodnia/Windows/NewFirmWindow.xaml.cs
@@ -42,6 +42,14 @@ namespace aplikacja_przychodnia.Windows
                 {
                     Output_Error.Text = "Wypełnij wszystkie pola!";
                 }
+                else if (!FirmLocalDataBase.IsNipAvailable(Input_NIP.Text))
+                {
+                    Output_Error.Text = "Firma o tym numerze NIP jest już zapisana w bazie!";
+                }
+                else if (!FirmLocalDataBase.IsNameAvailable(Input_FirmName.Text))
+                {
+                    Output_Error.Text = "Firma o tej nazwie jest już zapisana w bazie!";
+                }
                 else
                 {
                     Firm firm = new Firm();
@@ -73,7 +81,7 @@ namespace aplikacja_przychodnia.Windows
             }
             else
             {
-                MessageBox.Show("Nie można połączyć się z bazą");
+                Output_Error.Text = "Błędnie wpisany numer NIP!";
             }
         }
     }


### PR DESCRIPTION
Z raportu Zuzy (+ naprawione, - do zrobienia, * jest opis)
1. Doadwanie nowej firmy
+ możliwe jest dodanie firmy o istniejącym już w bazie NIPie
+ usuwanie firmy odbywa się poprzez wciśnięcie jednego przycisku, bez możliwości anulowania
+ możliwe dodanie firmy bez nazwy (puste pole "Nazwa")
+ możliwe dodanie firmy o istniejącej już w bazie nazwie

2. Wystawianie zwolnienia:
+ możliwe jest pozostawienie pustego pola "Powód zwolnienia" (?)
+ możliwe jest wystawienie zwolnienia na dowolnie długi okres i  od daty dwolonie odległej w przód
+ nie można wystawić zwolnienia na jeden dzień (ta sama data)
- niemożliwa ponowne wystawienie zwolnienia, jeśli plik PDF z poprzednim jest wciąż otwarty
*(U mnie działa) jeśli firmę wyszukano po nazie, wciśnięcie "Zapisz" generuje dwa alerty: "Wystąpił błąd" oraz "Brak połączenia z bazą" mimo połączenia z internetem i poprawnych danych firmy (problem nie występuje przy wyszukiwaniu po NIPie tej samej firmy)

3. ???
- po wywaleniu aplikacji otwartym PDFem, wraz z ponownym jej uruchomieniem wyskakuje alert z błędem, ale nie uniemożliwia dalszej pracy programu (błąd prawdopodobnie zniknie wraz z usunięciem reszty błędów c:)